### PR TITLE
Add coefficient dump utilities and test script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -190,6 +190,7 @@ TESTS = celt/tests/test_unit_cwrs32 \
         tests/test_opus_extensions \
         tests/test_opus_padding \
         tests/test_opus_projection
+       tests/test_dump.sh
 
 opus_demo_SOURCES = src/opus_demo.c
 if ENABLE_LOSSGEN
@@ -361,6 +362,7 @@ EXTRA_DIST = opus.pc.in \
              tests/meson.build \
              doc/meson.build \
              tests/run_vectors.sh \
+             tests/test_dump.sh \
              celt/arm/arm2gnu.pl \
              celt/arm/celt_pitch_xcorr_arm.s
 

--- a/celt/celt_decoder.c
+++ b/celt/celt_decoder.c
@@ -50,6 +50,7 @@
 #include <stdarg.h>
 #include "celt_lpc.h"
 #include "vq.h"
+#include "src/dump_coefs.h"
 
 #ifdef ENABLE_DEEP_PLC
 #include "lpcnet.h"
@@ -1294,6 +1295,7 @@ int celt_decode_with_ec_dred(CELTDecoder * OPUS_RESTRICT st, const unsigned char
          NULL, pulses, shortBlocks, spread_decision, dual_stereo, intensity, tf_res,
          len*(8<<BITRES)-anti_collapse_rsv, balance, dec, LM, codedBands, &st->rng, 0,
          st->arch, st->disable_inv);
+   dump_celt_coef(0, X, C*N);
 
    if (anti_collapse_rsv > 0)
    {

--- a/celt/celt_encoder.c
+++ b/celt/celt_encoder.c
@@ -50,6 +50,7 @@
 #include <stdarg.h>
 #include "celt_lpc.h"
 #include "vq.h"
+#include "src/dump_coefs.h"
 
 
 #ifndef M_PI
@@ -2454,6 +2455,7 @@ int celt_encode_with_ec(CELTEncoder * OPUS_RESTRICT st, const opus_res * pcm, in
 
    /* Residual quantisation */
    ALLOC(collapse_masks, C*nbEBands, unsigned char);
+   dump_celt_coef(1, X, C*N);
    quant_all_bands(1, mode, start, end, X, C==2 ? X+N : NULL, collapse_masks,
          bandE, pulses, shortBlocks, st->spread_decision,
          dual_stereo, st->intensity, tf_res, nbCompressedBytes*(8<<BITRES)-anti_collapse_rsv,

--- a/opus_headers.mk
+++ b/opus_headers.mk
@@ -6,3 +6,4 @@ src/opus_private.h \
 src/analysis.h \
 src/mapping_matrix.h \
 src/mlp.h
+src/dump_coefs.h

--- a/opus_sources.mk
+++ b/opus_sources.mk
@@ -9,7 +9,8 @@ src/opus_multistream_decoder.c \
 src/repacketizer.c \
 src/opus_projection_encoder.c \
 src/opus_projection_decoder.c \
-src/mapping_matrix.c
+src/mapping_matrix.c  \
+src/dump_coefs.c
 
 OPUS_SOURCES_FLOAT = \
 src/analysis.c \

--- a/silk/decode_parameters.c
+++ b/silk/decode_parameters.c
@@ -30,6 +30,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include "main.h"
+#include "src/dump_coefs.h"
 
 /* Decode parameters from payload */
 void silk_decode_parameters(
@@ -50,6 +51,7 @@ void silk_decode_parameters(
     /* Decode NLSFs */
     /****************/
     silk_NLSF_decode( pNLSF_Q15, psDec->indices.NLSFIndices, psDec->psNLSF_CB );
+    dump_silk_coef(0, pNLSF_Q15, psDec->LPC_order);
 
     /* Convert NLSF parameters to AR prediction filter coefficients */
     silk_NLSF2A( psDecCtrl->PredCoef_Q12[ 1 ], pNLSF_Q15, psDec->LPC_order, psDec->arch );

--- a/silk/decode_pulses.c
+++ b/silk/decode_pulses.c
@@ -30,6 +30,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include "main.h"
+#include "src/dump_coefs.h"
 
 /*********************************************/
 /* Decode quantization indices of excitation */
@@ -111,5 +112,6 @@ void silk_decode_pulses(
     /****************************************/
     /* Decode and add signs to pulse signal */
     /****************************************/
-    silk_decode_signs( psRangeDec, pulses, frame_length, signalType, quantOffsetType, sum_pulses );
+   silk_decode_signs( psRangeDec, pulses, frame_length, signalType, quantOffsetType, sum_pulses );
+   dump_silk_pulses16(0, pulses, frame_length);
 }

--- a/silk/encode_pulses.c
+++ b/silk/encode_pulses.c
@@ -31,6 +31,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 #include "main.h"
 #include "stack_alloc.h"
+#include "src/dump_coefs.h"
 
 /*********************************************/
 /* Encode quantization indices of excitation */
@@ -76,6 +77,8 @@ void silk_encode_pulses(
     const opus_uint8 *cdf_ptr;
     const opus_uint8 *nBits_ptr;
     SAVE_STACK;
+
+    dump_silk_pulses8(1, pulses, frame_length);
 
     silk_memset( pulses_comb, 0, 8 * sizeof( opus_int ) ); /* Fixing Valgrind reported problem*/
 

--- a/silk/process_NLSFs.c
+++ b/silk/process_NLSFs.c
@@ -30,6 +30,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include "main.h"
+#include "src/dump_coefs.h"
 
 /* Limit, stabilize, convert and quantize NLSFs */
 void silk_process_NLSFs(
@@ -85,6 +86,7 @@ void silk_process_NLSFs(
         }
     }
 
+    dump_silk_coef(1, pNLSF_Q15, psEncC->predictLPCOrder);
     silk_NLSF_encode( psEncC->indices.NLSFIndices, pNLSF_Q15, psEncC->psNLSF_CB, pNLSFW_QW,
         NLSF_mu_Q20, psEncC->NLSF_MSVQ_Survivors, psEncC->indices.signalType );
 

--- a/src/dump_coefs.c
+++ b/src/dump_coefs.c
@@ -1,0 +1,35 @@
+#include "src/dump_coefs.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+static void dump_array(const char *name,const void *data,size_t bytes)
+{
+    const char *dir=getenv("OPUS_DUMP_DIR");
+    if(!dir) return;
+    char path[512];
+    snprintf(path,sizeof(path),"%s/%s",dir,name);
+    FILE *f=fopen(path,"ab");
+    if(!f) return;
+    fwrite(data,1,bytes,f);
+    fclose(f);
+}
+
+void dump_silk_coef(int encode,const opus_int16 *vals,int len)
+{
+    dump_array(encode?"enc_silk.bin":"dec_silk.bin",vals,(size_t)len*sizeof(opus_int16));
+}
+
+void dump_silk_pulses8(int encode,const opus_int8 *vals,int len)
+{
+    dump_array(encode?"enc_silk.bin":"dec_silk.bin",vals,(size_t)len*sizeof(opus_int8));
+}
+
+void dump_silk_pulses16(int encode,const opus_int16 *vals,int len)
+{
+    dump_array(encode?"enc_silk.bin":"dec_silk.bin",vals,(size_t)len*sizeof(opus_int16));
+}
+
+void dump_celt_coef(int encode,const celt_norm *vals,int len)
+{
+    dump_array(encode?"enc_celt.bin":"dec_celt.bin",vals,(size_t)len*sizeof(celt_norm));
+}

--- a/src/dump_coefs.h
+++ b/src/dump_coefs.h
@@ -1,0 +1,9 @@
+#ifndef DUMP_COEFS_H
+#define DUMP_COEFS_H
+#include "opus_types.h"
+#include "celt/arch.h"
+void dump_silk_coef(int encode,const opus_int16 *vals,int len);
+void dump_silk_pulses8(int encode,const opus_int8 *vals,int len);
+void dump_silk_pulses16(int encode,const opus_int16 *vals,int len);
+void dump_celt_coef(int encode,const celt_norm *vals,int len);
+#endif

--- a/tests/test_dump.sh
+++ b/tests/test_dump.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+URL="https://opus-codec.org/static/examples/samples/speech_orig.wav"
+INPUT="speech_orig.wav"
+if [ ! -f "$INPUT" ]; then
+  curl -L -o "$INPUT" "$URL"
+fi
+rates="48000 24000 16000 12000 8000"
+for r in $rates; do
+  rm -rf dumps tmp.opus out.pcm
+  mkdir dumps
+  export OPUS_DUMP_DIR="dumps"
+  ./opus_demo voip $r 1 $r "$INPUT" tmp.opus > /dev/null
+  ./opus_demo -d $r 1 tmp.opus out.pcm > /dev/null
+  if [ -f dumps/enc_silk.bin ]; then
+    cmp dumps/enc_silk.bin dumps/dec_silk.bin
+  fi
+  if [ -f dumps/enc_celt.bin ]; then
+    cmp dumps/enc_celt.bin dumps/dec_celt.bin
+  fi
+  echo "Rate $r OK"
+  unset OPUS_DUMP_DIR
+done


### PR DESCRIPTION
## Summary
- add helper functions to dump SILK and CELT coefficients
- log coefficients in encoder and decoder paths
- add script to encode/decode test audio at several sample rates and compare dumps
- hook the new script into `make check`

## Testing
- `cmake ..`
- `cmake --build .`
- `./tests/test_dump.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68548f47682c83209abb64b59930abd4